### PR TITLE
Fix for refineries getting concealed after server restart, added option in settings to disable rc keepalive action.

### DIFF
--- a/Concealment/Concealment.csproj
+++ b/Concealment/Concealment.csproj
@@ -7,8 +7,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Concealment</RootNamespace>
     <AssemblyName>Concealment</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>

--- a/Concealment/ConcealmentControl.xaml
+++ b/Concealment/ConcealmentControl.xaml
@@ -19,6 +19,7 @@
                 <CheckBox Content="Enable Concealment" Margin="3" IsChecked="{Binding Enabled}" />
                 <CheckBox Content="Conceal Production" ToolTip="Conceal grids with active production blocks." Margin="3" IsChecked="{Binding ConcealProduction}" />
                 <CheckBox Content="Conceal Pirates" ToolTip="Conceal grids owned by Space Pirates." Margin="3" IsChecked="{Binding ConcealPirates}" />
+                <CheckBox Content="RC Keep Alive Action" ToolTip="Adds a toolbar action to remote control blocks to allow players to forcefully keep a grid from being concealed using a PB or Timer." Margin="3" IsChecked="{Binding RCKeepAliveAction}" />
                 <StackPanel Orientation="Horizontal">
                     <TextBox Margin="3" Width="150" Text="{Binding ConcealDistance}" />
                     <Label Content="Conceal Distance (meters)" Margin="3" />

--- a/Concealment/ConcealmentPlugin.cs
+++ b/Concealment/ConcealmentPlugin.cs
@@ -371,7 +371,7 @@ namespace Concealment
                     if (block == null)
                         continue;
 
-					if (block is MyRefinery r && !Settings.Data.ConcealProduction && !r.InputInventory.Empty())
+					if (block is MyRefinery r && !Settings.Data.ConcealProduction && !r.InputInventory.Empty() && r.IsFunctional && r.Enabled)
 					{
 						Log.Debug($"{group.GridNames} exempted refinery ({r.CustomName} active)");
 						exclude = true;
@@ -380,7 +380,7 @@ namespace Concealment
 
 					if (block is MyProductionBlock p && !Settings.Data.ConcealProduction && p.IsProducing)
 					{
-						Log.Debug($"{group.GridNames} exempted assembler ({p.CustomName} active)");
+						Log.Debug($"{group.GridNames} exempted production ({p.CustomName} active)");
 						exclude = true;
 						break;
 					}

--- a/Concealment/Settings.cs
+++ b/Concealment/Settings.cs
@@ -23,8 +23,10 @@ namespace Concealment
         private int _revealInterval = 60;
         private bool _concealProduction;
         private bool _concealPirates;
+        private bool _keepAliveAction;
 
-        private double _dynamicConcealQueryInterval = 15;
+
+		private double _dynamicConcealQueryInterval = 15;
         private double _dynamicConcealScanInterval = 2;
 
         /// <summary>
@@ -252,5 +254,15 @@ namespace Concealment
                 OnPropertyChanged();
             }
         }
-    }
+
+		public bool RCKeepAliveAction
+		{
+			get => _keepAliveAction;
+			set
+			{
+				_keepAliveAction = value;
+				OnPropertyChanged();
+			}
+		}
+	}
 }


### PR DESCRIPTION
_I ran into this issue a couple years ago, and forked the repo to fix it. Forgot about it until recently when I experienced the issue again._ 

Increasing the delay timer interval seems to fix the concealment on restart issue. The current value might not be long enough for larger servers. Also added a couple of checks for refineries to help prevent edge cases, maybe they help, maybe not, it's been a couple years since I made these changes.

I also added an option to the plugins settings to allow servers to disable the remote control block keepalive action if they so desired.