### PR TITLE
Added an option to disable the concealment of moving grids

### DIFF
--- a/Concealment/ConcealmentControl.xaml
+++ b/Concealment/ConcealmentControl.xaml
@@ -17,6 +17,7 @@
         <StackPanel Grid.Row="0">
             <StackPanel DataContext="{Binding Settings.Data}">
                 <CheckBox Content="Enable Concealment" Margin="3" IsChecked="{Binding Enabled}" />
+                <CheckBox Content="Conceal Grids In Movement (above 20m/s)" Margin="3" IsChecked="{Binding ConcealInMovement}" />
                 <CheckBox Content="Conceal Production" ToolTip="Conceal grids with active production blocks." Margin="3" IsChecked="{Binding ConcealProduction}" />
                 <CheckBox Content="Conceal Pirates" ToolTip="Conceal grids owned by Space Pirates." Margin="3" IsChecked="{Binding ConcealPirates}" />
                 <CheckBox Content="RC Keep Alive Action" ToolTip="Adds a toolbar action to remote control blocks to allow players to forcefully keep a grid from being concealed using a PB or Timer." Margin="3" IsChecked="{Binding RCKeepAliveAction}" />

--- a/Concealment/ConcealmentPlugin.cs
+++ b/Concealment/ConcealmentPlugin.cs
@@ -95,7 +95,7 @@ namespace Concealment
             if (_ready)
             {
                 if (_counter % (ulong)Settings.Data.ConcealInterval == 0)
-                    ConcealGrids(Settings.Data.ConcealDistance);
+                    ConcealGrids(Settings.Data.ConcealDistance, Settings.Data.ConcealInMovement);
                 if (_counter % (ulong)Settings.Data.RevealInterval == 0)
                     RevealGrids(Settings.Data.RevealDistance);
                 _counter += 1;
@@ -329,7 +329,7 @@ namespace Concealment
             return revealed;
         }
 
-        public int ConcealGrids(double distanceFromPlayers = 0)
+        public int ConcealGrids(double distanceFromPlayers = 0, bool concealInMovement = false)
         {
             Log.Debug("Concealing grids");
 
@@ -341,6 +341,25 @@ namespace Concealment
             Parallel.ForEach(MyCubeGridGroups.Static.Physical.Groups, group =>
             {
                 var concealGroup = new ConcealGroup(group);
+
+                if (!concealInMovement)
+                {
+                    var isInMovement = false;
+                    foreach (var grid in group.Nodes)
+                    {
+                        if (grid?.NodeData?.Speed > 20f)
+                        {
+                            isInMovement = true;
+                            break;
+                        }
+                    }
+
+                    if (isInMovement)
+                    {
+                        Log.Trace("group in movement");
+                        return;
+                    }
+                }
 
                 if (distanceFromPlayers != 0)
                 {

--- a/Concealment/Settings.cs
+++ b/Concealment/Settings.cs
@@ -17,6 +17,7 @@ namespace Concealment
     public class Settings : ViewModel
     {
         private bool _enabled = true;
+        private bool _concealInMovement;
         private double _concealDistance = 75000;
         private int _concealInterval = 3600;
         private double _revealDistance = 50000;
@@ -193,6 +194,16 @@ namespace Concealment
             set
             {
                 _enabled = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public bool ConcealInMovement
+        {
+            get => _concealInMovement;
+            set
+            {
+                _concealInMovement = value;
                 OnPropertyChanged();
             }
         }


### PR DESCRIPTION
Added this option, cause in my server, when big grids in movement conceals, they become really buggy.

Making longer travels in sub-light speeds inviable.